### PR TITLE
add example outputs in dkdeploy-php

### DIFF
--- a/rake/dkdeploy-php/db.md
+++ b/rake/dkdeploy-php/db.md
@@ -24,7 +24,38 @@ $ cap dev db:migrations:generate
 ### Output
 
 {% highlight shell %}
-	TODO
+$ cap dev db:migrations:generate
+ 00:00 db:migrations:copy_doctrine_to_server
+       ./vendor/doctrine-migrations.phar found.
+       Removing old migrations.
+       01 rm -rf /var/www/dkdeploy/shared/migrations
+     ✔ 01 vagrant@dkdeploy-php.dev 0.593s
+       Creating directories for migrations.
+       02 mkdir -p /var/www/dkdeploy/shared/migrations/classes
+     ✔ 02 vagrant@dkdeploy-php.dev 0.361s
+       Copying doctrine-migrations.phar to /var/www/dkdeploy/shared/migrations directory.
+       Uploading ./vendor/doctrine-migrations.phar 10.75%
+       Uploading ./vendor/doctrine-migrations.phar 20.3%
+       Uploading ./vendor/doctrine-migrations.phar 31.04%
+       Uploading ./vendor/doctrine-migrations.phar 40.6%
+       Uploading ./vendor/doctrine-migrations.phar 50.15%
+       Uploading ./vendor/doctrine-migrations.phar 60.9%
+       Uploading ./vendor/doctrine-migrations.phar 70.45%
+       Uploading ./vendor/doctrine-migrations.phar 81.19%
+       Uploading ./vendor/doctrine-migrations.phar 90.75%
+       Uploading ./vendor/doctrine-migrations.phar 100.0%
+       Copying db-configuration.php to /var/www/dkdeploy/shared/migrations.
+       Downloading db_settings.dev.yaml 100.0%
+       Uploading /var/www/dkdeploy/shared/migrations/cli-config.php 100.0%
+       Uploading /var/www/dkdeploy/shared/migrations/migrations.yml 100.0%
+ 00:01 db:migrations:generate
+       Generating new migration.
+       01 mkdir -p /var/www/dkdeploy/shared/migrations
+     ✔ 01 vagrant@dkdeploy-php.dev 0.008s
+       02 /usr/bin/php doctrine-migrations.phar migrations:generate --no-interaction
+       02 Generated new migration class to "/var/www/dkdeploy/shared/migrations/classes/Version20170419091311.php"
+     ✔ 02 vagrant@dkdeploy-php.dev 0.055s
+       Downloading config/migrations/classes/Version20170419091311.php 100.0%
 {% endhighlight %}
 
 ### Additional information
@@ -44,7 +75,53 @@ $ cap dev db:migrations:status
 ### Output
 
 {% highlight shell %}
-	TODO
+$  cap dev db:migrations:status
+  00:00 db:migrations:copy_doctrine_to_server
+        ./vendor/doctrine-migrations.phar found.
+        Removing old migrations.
+        01 rm -rf /var/www/dkdeploy/shared/migrations
+      ✔ 01 vagrant@dkdeploy-php.dev 0.584s
+        Creating directories for migrations.
+        02 mkdir -p /var/www/dkdeploy/shared/migrations/classes
+      ✔ 02 vagrant@dkdeploy-php.dev 0.357s
+        Copying doctrine-migrations.phar to /var/www/dkdeploy/shared/migrations directory.
+        Uploading ./vendor/doctrine-migrations.phar 10.75%
+        Uploading ./vendor/doctrine-migrations.phar 20.3%
+        Uploading ./vendor/doctrine-migrations.phar 31.04%
+        Uploading ./vendor/doctrine-migrations.phar 40.6%
+        Uploading ./vendor/doctrine-migrations.phar 50.15%
+        Uploading ./vendor/doctrine-migrations.phar 60.9%
+        Uploading ./vendor/doctrine-migrations.phar 70.45%
+        Uploading ./vendor/doctrine-migrations.phar 81.19%
+        Uploading ./vendor/doctrine-migrations.phar 90.75%
+        Uploading ./vendor/doctrine-migrations.phar 100.0%
+        Copying db-configuration.php to /var/www/dkdeploy/shared/migrations.
+        Downloading db_settings.dev.yaml 100.0%
+        Uploading /var/www/dkdeploy/shared/migrations/cli-config.php 100.0%
+        Uploading /var/www/dkdeploy/shared/migrations/migrations.yml 100.0%
+  00:01 db:migrations:copy_migrations_to_server
+        Uploading migrations to /var/www/dkdeploy/shared/migrations/classes.
+        01 rm -rf /var/www/dkdeploy/shared/migrations/classes
+      ✔ 01 vagrant@dkdeploy-php.dev 0.006s
+  00:01 db:migrations:status
+        Getting status of migrations.
+        01 /usr/bin/php doctrine-migrations.phar migrations:status
+        01 
+        01  == Configuration
+        01 
+        01     >> Name:                                               Doctrine TYPO3 Migrations
+        01     >> Database Driver:                                    pdo_mysql
+        01     >> Database Name:                                      dkdeploy_php
+        01     >> Configuration Source:                               /var/www/dkdeploy/shared/migrations/migrations.yml
+        01     >> Version Table Name:                                 doctrine_migrations
+        01     >> Migrations Namespace:                               DoctrineMigrations
+        01     >> Migrations Directory:                               /var/www/dkdeploy/shared/migrations/classes
+        01     >> Current Version:                                    0
+        01     >> Latest Version:                                     0
+        01     >> Executed Migrations:                                0
+        01     >> Available Migrations:                               0
+        01     >> New Migrations:                                     0
+      ✔ 01 vagrant@dkdeploy-php.dev 0.051s
 {% endhighlight %}
 
 ### Additional information
@@ -70,7 +147,67 @@ $ cap dev db:migrations:migrate
 ### Output
 
 {% highlight shell %}
-    TODO
+$ cap dev db:migrations:migrate
+00:00 db:migrations:copy_doctrine_to_server
+      ./vendor/doctrine-migrations.phar found.
+      Removing old migrations.
+      01 rm -rf /var/www/dkdeploy/shared/migrations
+    ✔ 01 vagrant@dkdeploy-php.dev 0.379s
+      Creating directories for migrations.
+      02 mkdir -p /var/www/dkdeploy/shared/migrations/classes
+    ✔ 02 vagrant@dkdeploy-php.dev 0.379s
+      Copying doctrine-migrations.phar to /var/www/dkdeploy/shared/migrations directory.
+      Uploading ./vendor/doctrine-migrations.phar 10.75%
+      Uploading ./vendor/doctrine-migrations.phar 20.3%
+      Uploading ./vendor/doctrine-migrations.phar 31.04%
+      Uploading ./vendor/doctrine-migrations.phar 40.6%
+      Uploading ./vendor/doctrine-migrations.phar 50.15%
+      Uploading ./vendor/doctrine-migrations.phar 60.9%
+      Uploading ./vendor/doctrine-migrations.phar 70.45%
+      Uploading ./vendor/doctrine-migrations.phar 81.19%
+      Uploading ./vendor/doctrine-migrations.phar 90.75%
+      Uploading ./vendor/doctrine-migrations.phar 100.0%
+      Copying db-configuration.php to /var/www/dkdeploy/shared/migrations.
+      Downloading db_settings.dev.yaml 100.0%
+      Uploading /var/www/dkdeploy/shared/migrations/cli-config.php 100.0%
+      Uploading /var/www/dkdeploy/shared/migrations/migrations.yml 100.0%
+00:01 db:migrations:copy_migrations_to_server
+      Uploading migrations to /var/www/dkdeploy/shared/migrations/classes.
+      01 rm -rf /var/www/dkdeploy/shared/migrations/classes
+    ✔ 01 vagrant@dkdeploy-php.dev 0.008s
+      Uploading migrations for stage dev to /var/www/dkdeploy/shared/migrations/classes.
+      02 mkdir -p /var/www/dkdeploy/shared/migrations/classes
+    ✔ 02 vagrant@dkdeploy-php.dev 0.005s
+      Uploading config/migrations/stage/dev/Version22222222222222.php 100.0%
+      Uploading config/migrations/stage/dev/Version33333333333333.php 100.0%
+00:01 db:migrations:migrate
+      Migrating database.
+      01 /usr/bin/php doctrine-migrations.phar migrations:migrate --no-interaction
+      01                                                                  
+      01                     Doctrine TYPO3 Migrations                    
+      01                                                                  
+      01 
+      01 Migrating up to 33333333333333 from 0
+      01 
+      01   ++ migrating 22222222222222
+      01 
+      01 Migration 22222222222222 was executed but did not result in any SQL statements.
+      01 
+      01   ++ migrated (0s)
+      01 
+      01   ++ migrating 33333333333333
+      01 
+      01 Migration 33333333333333 was executed but did not result in any SQL statements.
+      01 
+      01   ++ migrated (0s)
+      01 
+      01   ------------------------
+      01 
+      01   ++ finished in 0
+      01   ++ 2 migrations executed
+      01   ++ 0 sql queries
+    ✔ 01 vagrant@dkdeploy-php.dev 0.064s
+
 {% endhighlight %}
 
 ### Additional information
@@ -94,14 +231,60 @@ set :migrations_default_arguments, ['--no-interaction']
 
 ### Usage
 
+Pass the targeting `migration_version` either as an argument (example in output section) or enter it interactively.
+
 {% highlight shell %}
 $ cap dev db:migrations:execute_down
 {% endhighlight %}
 
+
 ### Output
 
 {% highlight shell %}
-    TODO
+$ cap dev db:migrations:execute_down[33333333333333]
+00:00 db:migrations:copy_doctrine_to_server
+      ./vendor/doctrine-migrations.phar found.
+      Removing old migrations.
+      01 rm -rf /var/www/dkdeploy/shared/migrations
+    ✔ 01 vagrant@dkdeploy-php.dev 0.381s
+      Creating directories for migrations.
+      02 mkdir -p /var/www/dkdeploy/shared/migrations/classes
+    ✔ 02 vagrant@dkdeploy-php.dev 0.364s
+      Copying doctrine-migrations.phar to /var/www/dkdeploy/shared/migrations directory.
+      Uploading ./vendor/doctrine-migrations.phar 10.75%
+      Uploading ./vendor/doctrine-migrations.phar 20.3%
+      Uploading ./vendor/doctrine-migrations.phar 31.04%
+      Uploading ./vendor/doctrine-migrations.phar 40.6%
+      Uploading ./vendor/doctrine-migrations.phar 50.15%
+      Uploading ./vendor/doctrine-migrations.phar 60.9%
+      Uploading ./vendor/doctrine-migrations.phar 70.45%
+      Uploading ./vendor/doctrine-migrations.phar 81.19%
+      Uploading ./vendor/doctrine-migrations.phar 90.75%
+      Uploading ./vendor/doctrine-migrations.phar 100.0%
+      Copying db-configuration.php to /var/www/dkdeploy/shared/migrations.
+      Downloading db_settings.dev.yaml 100.0%
+      Uploading /var/www/dkdeploy/shared/migrations/cli-config.php 100.0%
+      Uploading /var/www/dkdeploy/shared/migrations/migrations.yml 100.0%
+00:00 db:migrations:copy_migrations_to_server
+      Uploading migrations to /var/www/dkdeploy/shared/migrations/classes.
+      01 rm -rf /var/www/dkdeploy/shared/migrations/classes
+    ✔ 01 vagrant@dkdeploy-php.dev 0.006s
+      Uploading migrations for stage dev to /var/www/dkdeploy/shared/migrations/classes.
+      02 mkdir -p /var/www/dkdeploy/shared/migrations/classes
+    ✔ 02 vagrant@dkdeploy-php.dev 0.006s
+      Uploading config/migrations/stage/dev/Version22222222222222.php 100.0%
+      Uploading config/migrations/stage/dev/Version33333333333333.php 100.0%
+      Uploading config/migrations/stage/dev/Version44444444444444.php 100.0%
+      Migrating down to version 33333333333333
+      03 /usr/bin/php doctrine-migrations.phar migrations:execute 33333333333333 --down --no-interaction
+      03 
+      03   -- reverting 33333333333333
+      03 
+      03 Migration 33333333333333 was executed but did not result in any SQL statements.
+      03 
+      03   -- reverted (0.01s)
+    ✔ 03 vagrant@dkdeploy-php.dev 0.062s
+
 {% endhighlight %}
 
 ## copy\_doctrine\_to\_server


### PR DESCRIPTION
* adds the missing output examples for db tasks in `dkdeploy-php`. The tasks have been executed in test environment fixture.
* improves documentation of `db:migrations:execute_down`